### PR TITLE
Fixes non-portable way of executing pwd

### DIFF
--- a/bin/sstools-utils
+++ b/bin/sstools-utils
@@ -5,7 +5,7 @@ sstools_modifier=$1
 #execute global config file to get most up to date configurations
 #Not the most beautiful way to set an environmental variable but it works
 
-CURDIR=`/bin/pwd`
+CURDIR=$(pwd)
 BASEDIR=$(dirname $0)
 ABSPATH=$(readlink -f $0)
 ABSDIR=$(dirname $ABSPATH)


### PR DESCRIPTION
Calling the `pwd` command using the absolute path `/bin/pwd` is non-portable, since the executable might be placed somewhere else depending on with Linux-distribution is being used. This commit fixes this by executing `pwd` without an absolute path, instead relying on `$PATH`. 

The reason I found this problem is that in my Linux-distribution `pwd` is not placed inside `/bin`, which resulted in this error for me:

```
bin/sstools-utils: line 8: /bin/pwd: No such file or directory
```